### PR TITLE
fix: default of getenv() should use ternary operator

### DIFF
--- a/src/LaravelFilesystem/copy/config/plugin/filesystems.php
+++ b/src/LaravelFilesystem/copy/config/plugin/filesystems.php
@@ -3,7 +3,7 @@
 if (!function_exists('get_env')) {
     function get_env(string $key, $default = null)
     {
-        return getenv($key) ?? $default;
+        return getenv($key) ?: $default;
     }
 }
 


### PR DESCRIPTION
因為 `getenv()` 在沒有取得值時是回傳 `false` 如果使用 `??` 會被認為是 is set，結果取得的資料就變成 `false` 而非想像中的 `$default`